### PR TITLE
add includes to make non-pch build compile

### DIFF
--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV1/Server/OnlineAsyncTaskAccelByteRegisterDedicatedV1Session.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV1/Server/OnlineAsyncTaskAccelByteRegisterDedicatedV1Session.cpp
@@ -10,6 +10,7 @@
 #include "GameServerApi/AccelByteServerSessionBrowserApi.h"
 #include "SocketSubsystem.h"
 #include "Core/AccelByteUtilities.h"
+#include "Engine/Engine.h"
 
 FOnlineAsyncTaskAccelByteRegisterDedicatedV1Session::FOnlineAsyncTaskAccelByteRegisterDedicatedV1Session(FOnlineSubsystemAccelByte* const InABInterface, int32 InHostingPlayerNum, FName InSessionName, const FOnlineSessionSettings& InNewSessionSettings, bool InRegisterToSessionBrowser)
 	: FOnlineAsyncTaskAccelByte(InABInterface)

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Statistic/OnlineAsyncTaskAccelByteResetUserStats.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Statistic/OnlineAsyncTaskAccelByteResetUserStats.cpp
@@ -203,3 +203,4 @@ void FOnlineAsyncTaskAccelByteResetUserStats::OnResetUserStatItemsFailed(int32 C
 
 	AB_OSS_ASYNC_TASK_TRACE_END(TEXT(""));
 }
+#undef ONLINE_ERROR_NAMESPACE

--- a/Source/OnlineSubsystemAccelByte/Private/ExecTests/ExecTestQueryExternalIds.h
+++ b/Source/OnlineSubsystemAccelByte/Private/ExecTests/ExecTestQueryExternalIds.h
@@ -3,7 +3,7 @@
 // and restrictions contact your company contract manager.
 
 #pragma once
-
+#include "Runtime/Launch/Resources/Version.h"
 #include "CoreMinimal.h"
 #if ENGINE_MAJOR_VERSION >= 5
 #include "Online/CoreOnline.h"

--- a/Source/OnlineSubsystemAccelByte/Private/ExecTests/ExecTestQueryUserIdMapping.h
+++ b/Source/OnlineSubsystemAccelByte/Private/ExecTests/ExecTestQueryUserIdMapping.h
@@ -3,7 +3,7 @@
 // and restrictions contact your company contract manager.
 
 #pragma once
-
+#include "Runtime/Launch/Resources/Version.h"
 #include "CoreMinimal.h"
 #if ENGINE_MAJOR_VERSION >= 5
 #include "Online/CoreOnline.h"

--- a/Source/OnlineSubsystemAccelByte/Private/OnlineAuthHandlerComponentAccelByte.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/OnlineAuthHandlerComponentAccelByte.cpp
@@ -8,6 +8,9 @@
 #include "Misc/AES.h"
 #include "OnlineSubsystemUtils.h"
 
+#include "GameFramework/PlayerController.h"
+#include "Engine/NetConnection.h"
+
 /** The maximum size (bits) for a packet */
 #define MAX_PACKET_BITS ((MAX_PACKET_SIZE) * 8)
 

--- a/Source/OnlineSubsystemAccelByte/Public/OnlineChatInterfaceAccelByte.h
+++ b/Source/OnlineSubsystemAccelByte/Public/OnlineChatInterfaceAccelByte.h
@@ -3,7 +3,7 @@
 // and restrictions contact your company contract manager.
 
 #pragma once
-
+#include "Runtime/Launch/Resources/Version.h"
 #include "CoreMinimal.h"
 #if ENGINE_MAJOR_VERSION >= 5
 #include "Online/CoreOnline.h"

--- a/Source/OnlineSubsystemAccelByte/Public/OnlineIdentityInterfaceAccelByte.h
+++ b/Source/OnlineSubsystemAccelByte/Public/OnlineIdentityInterfaceAccelByte.h
@@ -3,7 +3,7 @@
 // and restrictions contact your company contract manager.
 
 #pragma once
-
+#include "Launch/Resources/Version.h"
 #include "CoreMinimal.h"
 #if ENGINE_MAJOR_VERSION >= 5
 #include "Online/CoreOnline.h"

--- a/Source/OnlineSubsystemAccelByte/Public/OnlinePresenceInterfaceAccelByte.h
+++ b/Source/OnlineSubsystemAccelByte/Public/OnlinePresenceInterfaceAccelByte.h
@@ -2,7 +2,7 @@
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once
-
+#include "Runtime/Launch/Resources/Version.h"
 #include "CoreMinimal.h"
 #if ENGINE_MAJOR_VERSION >= 5
 #include "Online/CoreOnline.h"

--- a/Source/OnlineSubsystemAccelByte/Public/OnlineUserCacheAccelByte.h
+++ b/Source/OnlineSubsystemAccelByte/Public/OnlineUserCacheAccelByte.h
@@ -4,6 +4,7 @@
 
 #pragma once
 #include "OnlineSubsystemAccelByteTypes.h"
+#include "Dom/JsonObject.h"
 
 class FOnlineSubsystemAccelByte;
 class IOnlineSubsystem;


### PR DESCRIPTION
When building with no precompiled headers, these includes must be included for compilation