### PR TITLE
Fix a connection timeout bug if the lobby is already connected

### DIFF
--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/OnlineAsyncTaskAccelByteConnectLobby.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/OnlineAsyncTaskAccelByteConnectLobby.cpp
@@ -37,7 +37,14 @@ void FOnlineAsyncTaskAccelByteConnectLobby::Initialize()
 	// Send off a request to connect to the lobby websocket, as well as connect our delegates for doing so
 	ApiClient->Lobby.SetConnectSuccessDelegate(OnLobbyConnectSuccessDelegate);
 	ApiClient->Lobby.SetConnectFailedDelegate(OnLobbyConnectErrorDelegate);
-	ApiClient->Lobby.Connect();
+	if (ApiClient->Lobby.IsConnected())
+	{
+		OnLobbyConnectSuccess();
+	}
+	else
+	{
+		ApiClient->Lobby.Connect();
+	}
 
 	AB_OSS_ASYNC_TASK_TRACE_END(TEXT(""));
 }


### PR DESCRIPTION
If the Lobby is already connected when the AsyncTask to connect a lobby starts, the lobby will silently drop the request to connect because it's already connected. Thus the AsyncTask is left waiting indefinitely for a callback. It eventually gets timed out after 60s or so at which point it then reports connection _failure_ despite being connected.

I discovered this while testing our auto login flow in PIE Standalone mode. Effectively after the first PIE session the Lobby connection appears to not be disconnected. Thus when running PIE a second time the lobby is already connected and when the auto-login tries to establish a lobby connection it ultimately fails as described above.

While I think this change will fix issues where you request a lobby connection after the lobby is already connected, there may be another issue with the lobby connection sticking around unexpectedly. Would it be possible to for the existing lobby connection to be authorized for the previous user if a sign I used a different user on subsequent PIE sessions?