### PR TITLE
Fix compile error during Unity build

### DIFF
--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Statistic/OnlineAsyncTaskAccelByteResetUserStats.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Statistic/OnlineAsyncTaskAccelByteResetUserStats.cpp
@@ -203,3 +203,5 @@ void FOnlineAsyncTaskAccelByteResetUserStats::OnResetUserStatItemsFailed(int32 C
 
 	AB_OSS_ASYNC_TASK_TRACE_END(TEXT(""));
 }
+
+#undef ONLINE_ERROR_NAMESPACE

--- a/Source/OnlineSubsystemAccelByte/Private/OnlineAchievementsInterfaceAccelByte.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/OnlineAchievementsInterfaceAccelByte.cpp
@@ -123,8 +123,10 @@ void FOnlineAchievementsAccelByte::WriteAchievements(const FUniqueNetId& PlayerI
 	UE_LOG_AB(Error, TEXT("error. not implemented function. FOnlineAchievementsAccelByte::WriteAchievements"))
 }
 
+#if !UE_BUILD_SHIPPING
 bool FOnlineAchievementsAccelByte::ResetAchievements(const FUniqueNetId& PlayerId)
 {
 	UE_LOG_AB(Error, TEXT("error. not implemented function. FOnlineAchievementsAccelByte::ResetAchievements"))
 	return false;
 }
+#endif // !UE_BUILD_SHIPPING

--- a/Source/OnlineSubsystemAccelByte/Public/OnlineAchievementsInterfaceAccelByte.h
+++ b/Source/OnlineSubsystemAccelByte/Public/OnlineAchievementsInterfaceAccelByte.h
@@ -56,7 +56,9 @@ public:
 		const FUniqueNetId& PlayerId,
 		const FString& AchievementId,
 	    FOnlineAchievement& OutAchievement) override;
+#if !UE_BUILD_SHIPPING
 	virtual bool ResetAchievements(const FUniqueNetId& PlayerId) override;
+#endif // !UE_BUILD_SHIPPING
 	//~ End IOnlineAchievement Interface
 	
 protected:


### PR DESCRIPTION
ONLINE_ERROR_NAMESPACE can leak into other files and trigger a compile error about it being defined multiple times. I've added a fix for compiling the achievements implementation for a Shipping target as well.