### PR TITLE
Fix FMultiRegistry keys used during login for PIE

### DIFF
--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteSimultaneousLogin.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteSimultaneousLogin.cpp
@@ -77,14 +77,8 @@ void FOnlineAsyncTaskAccelByteSimultaneousLogin::Initialize()
 		return;
 	}
 
-	if (Subsystem->IsMultipleLocalUsersEnabled())
-	{
-		SetApiClient(FMultiRegistry::GetApiClient(FString::Printf(TEXT("%d"), LoginUserNum)));
-	}
-	else
-	{
-		SetApiClient(FMultiRegistry::GetApiClient());
-	}
+	InitApiClient();
+
 	API_CLIENT_CHECK_GUARD(ErrorStr);
 	ApiClient->CredentialsRef->SetClientCredentials(FRegistry::Settings.ClientId, FRegistry::Settings.ClientSecret);
 	

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/LoginQueue/OnlineAsyncTaskAccelByteLoginQueue.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/LoginQueue/OnlineAsyncTaskAccelByteLoginQueue.cpp
@@ -139,15 +139,8 @@ void FOnlineAsyncTaskAccelByteLoginQueue::ClaimAccessToken(const FString& InTick
 {
 	AB_OSS_ASYNC_TASK_TRACE_BEGIN(TEXT("LocalUserNum: %d, TicketId: %s"), LoginUserNum, *InTicketId);
 
-	if (Subsystem->IsMultipleLocalUsersEnabled())
-	{
-		SetApiClient(FMultiRegistry::GetApiClient(FString::Printf(TEXT("%d"), LoginUserNum)));
-	}
-	else
-	{
-		SetApiClient(FMultiRegistry::GetApiClient());
-	}
-	
+	InitApiClientForLogin(LoginUserNum);
+
 	if(!IsApiClientValid())
 	{
 		AB_OSS_ASYNC_TASK_TRACE_END(TEXT("Unable to claim access token, ApiClient is invalid"));

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/LoginQueue/OnlineAsyncTaskAccelByteLoginQueueCancelTicket.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/LoginQueue/OnlineAsyncTaskAccelByteLoginQueueCancelTicket.cpp
@@ -25,15 +25,8 @@ void FOnlineAsyncTaskAccelByteLoginQueueCancelTicket::Initialize()
 
 	Super::Initialize();
 	
-	if (Subsystem->IsMultipleLocalUsersEnabled())
-	{
-		SetApiClient(FMultiRegistry::GetApiClient(FString::Printf(TEXT("%d"), LoginUserNum)));
-	}
-	else
-	{
-		SetApiClient(FMultiRegistry::GetApiClient());
-	}
-	
+	InitApiClientForLogin(LoginUserNum);
+		
 	API_CLIENT_CHECK_GUARD(ErrorStr);
 
 	OnCancelTicketSuccessHandler = TDelegateUtils<FVoidHandler>::CreateThreadSafeSelfPtr(this, &FOnlineAsyncTaskAccelByteLoginQueueCancelTicket::OnCancelTicketSuccess);

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/LoginQueue/OnlineAsyncTaskAccelByteLoginRefreshTicket.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/LoginQueue/OnlineAsyncTaskAccelByteLoginRefreshTicket.cpp
@@ -26,14 +26,7 @@ void FOnlineAsyncTaskAccelByteLoginRefreshTicket::Initialize()
 	Super::Initialize();
 
 	AB_OSS_ASYNC_TASK_TRACE_BEGIN(TEXT("LoginUserNum: %d"), LoginUserNum);
-	if (Subsystem->IsMultipleLocalUsersEnabled())
-	{
-		SetApiClient(FMultiRegistry::GetApiClient(FString::Printf(TEXT("%d"), LoginUserNum)));
-	}
-	else
-	{
-		SetApiClient(FMultiRegistry::GetApiClient());
-	}
+	InitApiClientForLogin(LoginUserNum);
 	
 	OnRefreshTicketSuccessHandler = TDelegateUtils<THandler<FAccelByteModelsLoginQueueTicketInfo>>::CreateThreadSafeSelfPtr(this, &FOnlineAsyncTaskAccelByteLoginRefreshTicket::OnRefreshTicketSuccess);
 	OnRefreshTicketErrorHandler = TDelegateUtils<FErrorHandler>::CreateThreadSafeSelfPtr(this, &FOnlineAsyncTaskAccelByteLoginRefreshTicket::OnRefreshTicketError);

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/OnlineAsyncTaskAccelByte.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/OnlineAsyncTaskAccelByte.cpp
@@ -4,6 +4,7 @@
 
 #include "AsyncTasks/OnlineAsyncTaskAccelByte.h"
 #include "AsyncTasks/OnlineAsyncEpicTaskAccelByte.h"
+#include "Core/AccelByteMultiRegistry.h"
 
 void FOnlineAsyncTaskAccelByte::ExecuteCriticalSectionAction(FVoidHandler Action)
 {
@@ -57,4 +58,16 @@ void FOnlineAsyncTaskAccelByte::ForcefullySetTimeoutState()
 	OnTaskTimedOut();
 	DeltaTickAccumulation += TaskTimeoutInSeconds;
 	LastTaskUpdateInSeconds -= TaskTimeoutInSeconds;
+}
+
+void FOnlineAsyncTaskAccelByte::InitApiClientForLogin(int LoginUserNum)
+{
+	if (Subsystem->IsMultipleLocalUsersEnabled())
+	{
+		SetApiClient(AccelByte::FMultiRegistry::GetApiClient(FString::Printf(TEXT("%s/%d"), *Subsystem->GetInstanceName().ToString(), LoginUserNum)));
+	}
+	else
+	{
+		SetApiClient(AccelByte::FMultiRegistry::GetApiClient());
+	}
 }

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/OnlineAsyncTaskAccelByteLogin.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/OnlineAsyncTaskAccelByteLogin.cpp
@@ -84,14 +84,7 @@ void FOnlineAsyncTaskAccelByteLogin::Initialize()
 	
 	GConfig->GetInt(TEXT("OnlineSubsystemAccelByte"), TEXT("LoginQueuePresentationThreshold"), LoginQueuePresentationThreshold, GEngineIni);
 
-	if (Subsystem->IsMultipleLocalUsersEnabled())
-	{
-		SetApiClient(FMultiRegistry::GetApiClient(FString::Printf(TEXT("%d"), LoginUserNum)));
-	}
-	else
-	{
-		SetApiClient(FMultiRegistry::GetApiClient());
-	}
+	InitApiClient();
 	
 	API_CLIENT_CHECK_GUARD();
 	//Valid because just recently SetApiClient()
@@ -215,6 +208,11 @@ void FOnlineAsyncTaskAccelByteLogin::TriggerDelegates()
 	}
 
 	AB_OSS_ASYNC_TASK_TRACE_END(TEXT(""));
+}
+
+void FOnlineAsyncTaskAccelByteLogin::InitApiClient()
+{
+	InitApiClientForLogin(LoginUserNum);
 }
 
 void FOnlineAsyncTaskAccelByteLogin::LoginWithNativeSubsystem()

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/OnlineAsyncTaskAccelByteLogin.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/OnlineAsyncTaskAccelByteLogin.h
@@ -161,6 +161,12 @@ protected:
 #endif
 
 	/**
+	 * Initializes the ApiClient for this login, using ContextName/LocalUserNum as the key if multiple users are enabled,
+	 * or using the global default ApiClient if not
+	 */
+	void InitApiClient();
+
+	/**
 	 * Attempts to fire off a login request with a native subsystem, if one is set up and usable.
 	 *
 	 * @param LocalUserNum Index of the user that we want to try and auth with native subsystem pass through

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteValidateUserInput.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteValidateUserInput.cpp
@@ -28,7 +28,7 @@ void FOnlineAsyncTaskAccelByteValidateUserInput::Initialize()
 	// Ensure to always get api client since the endpoint is able to call without authorization
 	if (Subsystem->GetApiClient(LocalUserNum) == nullptr)
 	{
-		SetApiClient(FMultiRegistry::GetApiClient(FString::Printf(TEXT("%d"), LocalUserNum)));
+		SetApiClient(FMultiRegistry::GetApiClient(FString::Printf(TEXT("%s/%d"), *Subsystem->GetInstanceName().ToString(), LocalUserNum)));
 	}
 	API_CLIENT_CHECK_GUARD(OnlineError)
 	

--- a/Source/OnlineSubsystemAccelByte/Public/AsyncTasks/OnlineAsyncTaskAccelByte.h
+++ b/Source/OnlineSubsystemAccelByte/Public/AsyncTasks/OnlineAsyncTaskAccelByte.h
@@ -496,6 +496,14 @@ protected:
 	}
 
 	/**
+	 * Initializes the ApiClient for this login, using ContextName/LocalUserNum as the key if multiple users are enabled,
+	 * or using the global default ApiClient if not
+	 *
+	 * @param LoginUserNum The local user num being used to temporarily identify an API client
+	 */
+	void InitApiClientForLogin(int LoginUserNum);
+	
+	/**
 	 * Sets current API client member (expected to be used by Login async tasks)
 	 */
 	void SetApiClient(AccelByte::FApiClientPtr Input)


### PR DESCRIPTION
When using Editor Preferences->Player Credentials to log in multiple PIE users automatically, LocalUserNum is not sufficient to uniquely identity users - they are all user number 0 in their local contexts.  This changes the key used during login to ContextName/UserNum to uniquely identify them.

Note that after they are logged in, the ApiClient is moved from this temporary login key to one using their AccelByteId.  But during login this is necessary.
