### PR TITLE
Remove BOM from all files

### DIFF
--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Achievement/OnlineAsyncTaskAccelByteQueryAchievement.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Achievement/OnlineAsyncTaskAccelByteQueryAchievement.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Achievement/OnlineAsyncTaskAccelByteQueryAchievement.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Achievement/OnlineAsyncTaskAccelByteQueryAchievement.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatDeleteSystemMessages.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatDeleteSystemMessages.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatDeleteSystemMessages.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatDeleteSystemMessages.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatGetConfig.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatGetConfig.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatGetConfig.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatGetConfig.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatGetSystemMessagesStats.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatGetSystemMessagesStats.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatGetSystemMessagesStats.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatGetSystemMessagesStats.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatQuerySystemMessages.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatQuerySystemMessages.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatQuerySystemMessages.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatQuerySystemMessages.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatQueryTransientSystemMessages.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatQueryTransientSystemMessages.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatQueryTransientSystemMessages.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatQueryTransientSystemMessages.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatReportMessage.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatReportMessage.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatReportMessage.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatReportMessage.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatUpdateSystemMessages.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatUpdateSystemMessages.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatUpdateSystemMessages.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteChatUpdateSystemMessages.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteGetUserChatConfiguration.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteGetUserChatConfiguration.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteGetUserChatConfiguration.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteGetUserChatConfiguration.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteSetUserChatConfiguration.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteSetUserChatConfiguration.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteSetUserChatConfiguration.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Chat/OnlineAsyncTaskAccelByteSetUserChatConfiguration.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteConsumeEntitlement.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteConsumeEntitlement.cpp
@@ -1,4 +1,4 @@
-﻿#include "OnlineAsyncTaskAccelByteConsumeEntitlement.h"
+#include "OnlineAsyncTaskAccelByteConsumeEntitlement.h"
 
 #include "OnlineEntitlementsInterfaceAccelByte.h"
 #include "Interfaces/OnlineEntitlementsInterface.h"

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteConsumeEntitlement.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteConsumeEntitlement.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteGetCurrentUserEntitlementHistory.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteGetCurrentUserEntitlementHistory.cpp
@@ -1,4 +1,4 @@
-﻿#include "OnlineAsyncTaskAccelByteGetCurrentUserEntitlementHistory.h"
+#include "OnlineAsyncTaskAccelByteGetCurrentUserEntitlementHistory.h"
 
 #include "OnlineEntitlementsInterfaceAccelByte.h"
 #include "Interfaces/OnlineEntitlementsInterface.h"

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteGetCurrentUserEntitlementHistory.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteGetCurrentUserEntitlementHistory.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteGetUserEntitlementHistory.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteGetUserEntitlementHistory.cpp
@@ -1,4 +1,4 @@
-﻿#include "OnlineAsyncTaskAccelByteGetUserEntitlementHistory.h"
+#include "OnlineAsyncTaskAccelByteGetUserEntitlementHistory.h"
 
 #include "OnlineEntitlementsInterfaceAccelByte.h"
 #include "Interfaces/OnlineEntitlementsInterface.h"

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteGetUserEntitlementHistory.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteGetUserEntitlementHistory.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteQueryEntitlements.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteQueryEntitlements.cpp
@@ -1,4 +1,4 @@
-﻿#include "OnlineAsyncTaskAccelByteQueryEntitlements.h"
+#include "OnlineAsyncTaskAccelByteQueryEntitlements.h"
 
 #include "OnlineEntitlementsInterfaceAccelByte.h"
 #include "Interfaces/OnlineEntitlementsInterface.h"

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteQueryEntitlements.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteQueryEntitlements.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteQueryPlatformSubscription.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteQueryPlatformSubscription.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteSyncMetaQuestDLC.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteSyncMetaQuestDLC.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteSyncMetaQuestDLC.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteSyncMetaQuestDLC.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteSyncMetaQuestIAP.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteSyncMetaQuestIAP.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteSyncMetaQuestIAP.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteSyncMetaQuestIAP.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteSyncSteamAbnormalIAPTransaction.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteSyncSteamAbnormalIAPTransaction.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2025 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteSyncSteamAbnormalIAPTransaction.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteSyncSteamAbnormalIAPTransaction.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2025 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteSyncSteamIAPTransaction.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteSyncSteamIAPTransaction.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2025 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteSyncSteamIAPTransaction.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Entitlements/OnlineAsyncTaskAccelByteSyncSteamIAPTransaction.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2025 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Friends/OnlineAsyncTaskAccelByteSyncPlatformFriend.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Friends/OnlineAsyncTaskAccelByteSyncPlatformFriend.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Friends/OnlineAsyncTaskAccelByteSyncPlatformFriend.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Friends/OnlineAsyncTaskAccelByteSyncPlatformFriend.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Friends/OnlineAsyncTaskAccelByteSyncThirPartyFriend.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Friends/OnlineAsyncTaskAccelByteSyncThirPartyFriend.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Friends/OnlineAsyncTaskAccelByteSyncThirPartyFriend.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Friends/OnlineAsyncTaskAccelByteSyncThirPartyFriend.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteDisableMfaAuthenticator.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteDisableMfaAuthenticator.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteDisableMfaAuthenticator.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteDisableMfaAuthenticator.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteDisableMfaBackupCodes.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteDisableMfaBackupCodes.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteDisableMfaBackupCodes.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteDisableMfaBackupCodes.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteDisableMfaEmail.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteDisableMfaEmail.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteDisableMfaEmail.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteDisableMfaEmail.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteEnableMfaAuthenticator.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteEnableMfaAuthenticator.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteEnableMfaAuthenticator.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteEnableMfaAuthenticator.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteEnableMfaBackupCodes.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteEnableMfaBackupCodes.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteEnableMfaBackupCodes.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteEnableMfaBackupCodes.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteEnableMfaEmail.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteEnableMfaEmail.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteEnableMfaEmail.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteEnableMfaEmail.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteGenerateCodeForPublisherToken.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteGenerateCodeForPublisherToken.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteGenerateCodeForPublisherToken.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteGenerateCodeForPublisherToken.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteGenerateMfaAuthenticatorSecretKey.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteGenerateMfaAuthenticatorSecretKey.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteGenerateMfaAuthenticatorSecretKey.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteGenerateMfaAuthenticatorSecretKey.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteGenerateMfaBackupCodes.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteGenerateMfaBackupCodes.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteGenerateMfaBackupCodes.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteGenerateMfaBackupCodes.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteGetMfaStatus.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteGetMfaStatus.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteGetMfaStatus.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteGetMfaStatus.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteRefreshPlatformToken.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteRefreshPlatformToken.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteRefreshPlatformToken.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteRefreshPlatformToken.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteSendMfaCodeToEmail.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteSendMfaCodeToEmail.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteSendMfaCodeToEmail.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteSendMfaCodeToEmail.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteUpdatePassword.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteUpdatePassword.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteUpdatePassword.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteUpdatePassword.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteVerifyLoginMfa.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteVerifyLoginMfa.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteVerifyLoginMfa.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Identity/OnlineAsyncTaskAccelByteVerifyLoginMfa.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Leaderboard/OnlineAsyncTaskAccelByteReadLeaderboardAroundUser.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Leaderboard/OnlineAsyncTaskAccelByteReadLeaderboardAroundUser.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Leaderboard/OnlineAsyncTaskAccelByteReadLeaderboardAroundUser.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Leaderboard/OnlineAsyncTaskAccelByteReadLeaderboardAroundUser.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteCancelV2PartyInvite.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteCancelV2PartyInvite.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteCancelV2PartyInvite.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteCancelV2PartyInvite.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteFindV2PartyById.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteFindV2PartyById.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteFindV2PartyById.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteFindV2PartyById.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteGenerateNewV2PartyCode.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteGenerateNewV2PartyCode.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteGenerateNewV2PartyCode.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteGenerateNewV2PartyCode.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteJoinV2PartyByCode.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteJoinV2PartyByCode.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteJoinV2PartyByCode.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteJoinV2PartyByCode.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteKickV2Party.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteKickV2Party.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteKickV2Party.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteKickV2Party.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteRefreshV2PartySession.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteRefreshV2PartySession.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteRefreshV2PartySession.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteRefreshV2PartySession.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteRevokeV2PartyCode.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteRevokeV2PartyCode.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteRevokeV2PartyCode.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteRevokeV2PartyCode.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteUpdatePartyV2.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteUpdatePartyV2.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteUpdatePartyV2.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteUpdatePartyV2.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteUpdateReservedPartyStorage.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteUpdateReservedPartyStorage.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteUpdateReservedPartyStorage.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/PartyV2/OnlineAsyncTaskAccelByteUpdateReservedPartyStorage.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Purchase/MetaQuest/OnlineAsyncTaskAccelByteCheckoutMetaQuestProduct.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Purchase/MetaQuest/OnlineAsyncTaskAccelByteCheckoutMetaQuestProduct.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Purchase/MetaQuest/OnlineAsyncTaskAccelByteCheckoutMetaQuestProduct.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Purchase/MetaQuest/OnlineAsyncTaskAccelByteCheckoutMetaQuestProduct.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Purchase/MetaQuest/OnlineAsyncTaskAccelByteGetMetaQuestPurchasedProducts.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Purchase/MetaQuest/OnlineAsyncTaskAccelByteGetMetaQuestPurchasedProducts.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Purchase/MetaQuest/OnlineAsyncTaskAccelByteGetMetaQuestPurchasedProducts.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Purchase/MetaQuest/OnlineAsyncTaskAccelByteGetMetaQuestPurchasedProducts.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Purchase/OnlineAsyncTaskAccelByteCheckout.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Purchase/OnlineAsyncTaskAccelByteCheckout.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Purchase/OnlineAsyncTaskAccelByteCheckout.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Purchase/OnlineAsyncTaskAccelByteCheckout.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Purchase/OnlineAsyncTaskAccelByteRedeemCode.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Purchase/OnlineAsyncTaskAccelByteRedeemCode.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 - 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 - 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Purchase/OnlineAsyncTaskAccelByteRedeemCode.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Purchase/OnlineAsyncTaskAccelByteRedeemCode.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Purchase/Steam/OnlineAsyncTaskAccelByteCheckoutSteamInventory.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Purchase/Steam/OnlineAsyncTaskAccelByteCheckoutSteamInventory.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Purchase/Steam/OnlineAsyncTaskAccelByteCheckoutSteamInventory.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Purchase/Steam/OnlineAsyncTaskAccelByteCheckoutSteamInventory.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteAcceptBackfillProposal.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteAcceptBackfillProposal.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteAcceptBackfillProposal.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteAcceptBackfillProposal.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteCreateBackfillTicket.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteCreateBackfillTicket.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteCreateBackfillTicket.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteCreateBackfillTicket.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteDeleteBackfillTicket.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteDeleteBackfillTicket.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteDeleteBackfillTicket.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteDeleteBackfillTicket.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteGetServerClaimedV2Session.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteGetServerClaimedV2Session.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteGetServerClaimedV2Session.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteGetServerClaimedV2Session.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteLoginServer.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteLoginServer.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteLoginServer.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteLoginServer.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteRegisterLocalServerV2.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteRegisterLocalServerV2.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteRegisterLocalServerV2.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteRegisterLocalServerV2.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteRegisterRemoteServerV2.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteRegisterRemoteServerV2.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteRegisterRemoteServerV2.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteRegisterRemoteServerV2.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteRejectBackfillProposal.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteRejectBackfillProposal.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteRejectBackfillProposal.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteRejectBackfillProposal.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteSendDSSessionReady.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteSendDSSessionReady.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteSendDSSessionReady.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteSendDSSessionReady.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteServerKickV2GameSession.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteServerKickV2GameSession.cpp
@@ -1,4 +1,4 @@
-﻿#include "OnlineAsyncTaskAccelByteServerKickV2GameSession.h"
+#include "OnlineAsyncTaskAccelByteServerKickV2GameSession.h"
 
 using namespace AccelByte;
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteServerKickV2GameSession.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteServerKickV2GameSession.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteServerQueryGameSessionsV2.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteServerQueryGameSessionsV2.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteServerQueryGameSessionsV2.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteServerQueryGameSessionsV2.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteServerQueryPartySessionsV2.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteServerQueryPartySessionsV2.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteServerQueryPartySessionsV2.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteServerQueryPartySessionsV2.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteUnregisterLocalServerV2.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteUnregisterLocalServerV2.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteUnregisterLocalServerV2.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteUnregisterLocalServerV2.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteUnregisterRemoteServerV2.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteUnregisterRemoteServerV2.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteUnregisterRemoteServerV2.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteUnregisterRemoteServerV2.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteUpdateDSInformation.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteUpdateDSInformation.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2025 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteUpdateDSInformation.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Server/OnlineAsyncTaskAccelByteUpdateDSInformation.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2025 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV1/OnlineAsyncTaskAccelByteFindV1GameSessionById.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV1/OnlineAsyncTaskAccelByteFindV1GameSessionById.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV1/OnlineAsyncTaskAccelByteFindV1GameSessionById.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV1/OnlineAsyncTaskAccelByteFindV1GameSessionById.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV1/Server/OnlineAsyncTaskAccelByteRemoveUserFromV1Session.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV1/Server/OnlineAsyncTaskAccelByteRemoveUserFromV1Session.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV1/Server/OnlineAsyncTaskAccelByteRemoveUserFromV1Session.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV1/Server/OnlineAsyncTaskAccelByteRemoveUserFromV1Session.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteCancelV2GameSessionInvite.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteCancelV2GameSessionInvite.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteCancelV2GameSessionInvite.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteCancelV2GameSessionInvite.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteFindGameSessionsV2.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteFindGameSessionsV2.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteFindGameSessionsV2.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteFindGameSessionsV2.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteFindV2GameSessionById.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteFindV2GameSessionById.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteFindV2GameSessionById.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteFindV2GameSessionById.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteJoinV2GameSession.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteJoinV2GameSession.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteJoinV2GameSession.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteJoinV2GameSession.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteKickV2GameSession.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteKickV2GameSession.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteKickV2GameSession.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteKickV2GameSession.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteLeaveV2GameSession.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteLeaveV2GameSession.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteLeaveV2GameSession.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteLeaveV2GameSession.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelBytePromoteV2GameSessionLeader.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelBytePromoteV2GameSessionLeader.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelBytePromoteV2GameSessionLeader.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelBytePromoteV2GameSessionLeader.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteQueryAllV2SessionInvites.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteQueryAllV2SessionInvites.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteQueryAllV2SessionInvites.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteQueryAllV2SessionInvites.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteRefreshActiveSessions.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteRefreshActiveSessions.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteRefreshActiveSessions.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteRefreshActiveSessions.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteRefreshV2ActiveSessions.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteRefreshV2ActiveSessions.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2025 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteRefreshV2ActiveSessions.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteRefreshV2ActiveSessions.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2025 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteRefreshV2GameSession.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteRefreshV2GameSession.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteRefreshV2GameSession.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteRefreshV2GameSession.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteUpdateGameSessionV2.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteUpdateGameSessionV2.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteUpdateGameSessionV2.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteUpdateGameSessionV2.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteUpdateLeaderSessionV2Storage.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteUpdateLeaderSessionV2Storage.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteUpdateLeaderSessionV2Storage.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteUpdateLeaderSessionV2Storage.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteUpdateMemberSessionV2Storage.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteUpdateMemberSessionV2Storage.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteUpdateMemberSessionV2Storage.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteUpdateMemberSessionV2Storage.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteUpdateMemberStatus.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteUpdateMemberStatus.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteUpdateMemberStatus.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/SessionV2/OnlineAsyncTaskAccelByteUpdateMemberStatus.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #pragma once

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Statistic/OnlineAsyncTaskAccelByteCreateStatsUser.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Statistic/OnlineAsyncTaskAccelByteCreateStatsUser.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/MetaQuest/OnlineAsyncTaskAccelByteGetMetaQuestProductsBySku.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/MetaQuest/OnlineAsyncTaskAccelByteGetMetaQuestProductsBySku.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/MetaQuest/OnlineAsyncTaskAccelByteGetMetaQuestProductsBySku.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/MetaQuest/OnlineAsyncTaskAccelByteGetMetaQuestProductsBySku.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryActiveSections.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryActiveSections.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryActiveSections.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryActiveSections.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryCategories.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryCategories.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryCategories.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryCategories.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryChildCategories.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryChildCategories.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryChildCategories.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryChildCategories.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryOfferByFilter.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryOfferByFilter.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryOfferByFilter.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryOfferByFilter.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryOfferById.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryOfferById.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryOfferById.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryOfferById.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryOfferBySku.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryOfferBySku.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryOfferBySku.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryOfferBySku.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryOfferDynamicData.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryOfferDynamicData.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryOfferDynamicData.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryOfferDynamicData.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryStorefront.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryStorefront.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryStorefront.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/Store/OnlineAsyncTaskAccelByteQueryStorefront.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteCheckUserAccountAvailability.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteCheckUserAccountAvailability.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteCheckUserAccountAvailability.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteCheckUserAccountAvailability.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteGetUserPlatformLinks.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteGetUserPlatformLinks.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteGetUserPlatformLinks.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteGetUserPlatformLinks.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteLinkOtherPlatform.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteLinkOtherPlatform.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteLinkOtherPlatform.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteLinkOtherPlatform.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteLinkOtherPlatformId.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteLinkOtherPlatformId.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteLinkOtherPlatformId.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteLinkOtherPlatformId.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteQueryUserIdMappingWithPlatform.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteQueryUserIdMappingWithPlatform.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteQueryUserIdMappingWithPlatform.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteQueryUserIdMappingWithPlatform.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteQueryUserIdMappingWithPlatformId.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteQueryUserIdMappingWithPlatformId.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteQueryUserIdMappingWithPlatformId.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteQueryUserIdMappingWithPlatformId.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteUnlinkOtherPlatform.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteUnlinkOtherPlatform.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteUnlinkOtherPlatform.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteUnlinkOtherPlatform.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteUnlinkOtherPlatformId.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteUnlinkOtherPlatformId.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteUnlinkOtherPlatformId.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteUnlinkOtherPlatformId.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteValidateUserInput.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteValidateUserInput.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteValidateUserInput.h
+++ b/Source/OnlineSubsystemAccelByte/Private/AsyncTasks/User/OnlineAsyncTaskAccelByteValidateUserInput.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/Blueprints/OnlineSubsystemAccelByteBlueprint.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/Blueprints/OnlineSubsystemAccelByteBlueprint.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 
 #include "Blueprints/OnlineSubsystemAccelByteBlueprint.h"
 

--- a/Source/OnlineSubsystemAccelByte/Private/OnlineAchievementsInterfaceAccelByte.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/OnlineAchievementsInterfaceAccelByte.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #include "OnlineAchievementsInterfaceAccelByte.h"

--- a/Source/OnlineSubsystemAccelByte/Private/OnlineAnalyticsInterfaceAccelByte.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/OnlineAnalyticsInterfaceAccelByte.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/OnlineEntitlementsInterfaceAccelByte.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/OnlineEntitlementsInterfaceAccelByte.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/OnlineLeaderboardInterfaceAccelByte.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/OnlineLeaderboardInterfaceAccelByte.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 #include "OnlineLeaderboardInterfaceAccelByte.h"

--- a/Source/OnlineSubsystemAccelByte/Private/OnlinePurchaseInterfaceAccelByte.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/OnlinePurchaseInterfaceAccelByte.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/OnlineStoreInterfaceV2AccelByte.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/OnlineStoreInterfaceV2AccelByte.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Private/OnlineTimeInterfaceAccelByte.cpp
+++ b/Source/OnlineSubsystemAccelByte/Private/OnlineTimeInterfaceAccelByte.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Public/Blueprints/OnlineSubsystemAccelByteBlueprint.h
+++ b/Source/OnlineSubsystemAccelByte/Public/Blueprints/OnlineSubsystemAccelByteBlueprint.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 
 #pragma once
 

--- a/Source/OnlineSubsystemAccelByte/Public/OnlineAchievementsInterfaceAccelByte.h
+++ b/Source/OnlineSubsystemAccelByte/Public/OnlineAchievementsInterfaceAccelByte.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Public/OnlineAnalyticsInterfaceAccelByte.h
+++ b/Source/OnlineSubsystemAccelByte/Public/OnlineAnalyticsInterfaceAccelByte.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Public/OnlineEntitlementsInterfaceAccelByte.h
+++ b/Source/OnlineSubsystemAccelByte/Public/OnlineEntitlementsInterfaceAccelByte.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Public/OnlineLeaderboardInterfaceAccelByte.h
+++ b/Source/OnlineSubsystemAccelByte/Public/OnlineLeaderboardInterfaceAccelByte.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Public/OnlinePurchaseInterfaceAccelByte.h
+++ b/Source/OnlineSubsystemAccelByte/Public/OnlinePurchaseInterfaceAccelByte.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Public/OnlineStoreInterfaceV2AccelByte.h
+++ b/Source/OnlineSubsystemAccelByte/Public/OnlineStoreInterfaceV2AccelByte.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Public/OnlineSubsystemAccelByte.h
+++ b/Source/OnlineSubsystemAccelByte/Public/OnlineSubsystemAccelByte.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/OnlineSubsystemAccelByte/Public/OnlineTimeInterfaceAccelByte.h
+++ b/Source/OnlineSubsystemAccelByte/Public/OnlineTimeInterfaceAccelByte.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 


### PR DESCRIPTION
When installing into a Perforce-backed project, BOM will cause p4 to use "utf8" filetype which can have undesirable effects. Remove all usages of BOM to eliminate such potential complications.